### PR TITLE
Bail out of && operator evaluation

### DIFF
--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -282,6 +282,7 @@ export function evaluate():{ confident: boolean; value: any } {
 
           return left || right;
         case "&&":
+          return;
 
           if ((!left && leftConfident) || (!right && rightConfident)) {
             confident = true;


### PR DESCRIPTION
I am not completely sure what goes wrong here but this fix at least avoids the oversimplification that is causing #2 